### PR TITLE
fix(guide): Korean typo 겄건이 → 경계

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1051,7 +1051,7 @@ var i18n = {
     "ch5.ctx.th.aggr": "Aggressive (6.4x)",
     "ch5.ctx.th.evict": "+ Eviction",
     "ch5.ctx.fastest": "OK (\uCD5C\uC18D)",
-    "ch5.ctx.borderline": "\uAC84\uAC74\uC774",
+    "ch5.ctx.borderline": "\uACBD\uACC4",
     "ch6.label": "6\uC7A5",
     "ch6.title": "\uC5F0\uAD6C \uAE30\uBC18",
     "ch6.intro": "quant.cpp\uC758 \uAC01 \uAE30\uC220\uC740 \uB3D9\uB8CC \uC2EC\uC0AC \uC5F0\uAD6C\uC5D0 \uAE30\uBC18\uD569\uB2C8\uB2E4:",


### PR DESCRIPTION
Korean translation for ch5.ctx.borderline was a nonsense string (겄건이). Changed to 경계 (boundary/borderline).