### PR TITLE
chore: sync __version__ fallback to 0.12.0

### DIFF
--- a/bindings/python/quantcpp/__init__.py
+++ b/bindings/python/quantcpp/__init__.py
@@ -15,7 +15,7 @@ try:
     from importlib.metadata import version as _pkg_version
     __version__ = _pkg_version("quantcpp")
 except Exception:
-    __version__ = "0.11.0"  # fallback for editable / source-tree imports
+    __version__ = "0.12.0"  # fallback for editable / source-tree imports
 
 import os
 import sys


### PR DESCRIPTION
Sync the source-tree __version__ fallback with pyproject.toml before tagging v0.12.0.